### PR TITLE
Fix instantiation links in method.md

### DIFF
--- a/docs/methods.md
+++ b/docs/methods.md
@@ -121,14 +121,14 @@ QuadKey.bbox(qks)  # -> [011, 013, 031, 033, 010, 012, 030, 032]
 ## QuadKey.from_geo (static)
 `from_geo(geo: Tuple[float, float], level: int) -> 'QuadKey'`
 
-See [instantiation](/instantiation).
+See [instantiation](instantiation.md).
 
 ## QuadKey.from_str (static)
 `from_str(qk_str: str) -> 'QuadKey'`
 
-See [instantiation](/instantiation).
+See [instantiation](instantiation.md).
 
 ## QuadKey.from_int (static)
 `from_int(qk_int: int) -> 'QuadKey'`
 
-See [instantiation](/instantiation).
+See [instantiation](instantiation.md).

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -121,14 +121,14 @@ QuadKey.bbox(qks)  # -> [011, 013, 031, 033, 010, 012, 030, 032]
 ## QuadKey.from_geo (static)
 `from_geo(geo: Tuple[float, float], level: int) -> 'QuadKey'`
 
-See [instantiation](instantiation.md).
+See [instantiation](instantiation.md#from-string-representation).
 
 ## QuadKey.from_str (static)
 `from_str(qk_str: str) -> 'QuadKey'`
 
-See [instantiation](instantiation.md).
+See [instantiation](instantiation.md#from-integer-representation).
 
 ## QuadKey.from_int (static)
 `from_int(qk_int: int) -> 'QuadKey'`
 
-See [instantiation](instantiation.md).
+See [instantiation](instantiation.md#from-coordinates).


### PR DESCRIPTION
Hi! I was reading through the docs and faced an issue with opening some links. 

The following section in the docs https://docs.muetsch.io/pyquadkey2/methods/#quadkeybbox-static` links to `https://docs.muetsch.io/instantiation` instead of `https://docs.muetsch.io/pyquadkey2/instantiation`

I think it is fixed when I added a `.md` to links and I also added fragment identifiers, 

Thanks! 