### PR TITLE
Allow inheritance

### DIFF
--- a/tests/test_quadkey.py
+++ b/tests/test_quadkey.py
@@ -119,6 +119,13 @@ class QuadKeyTest(TestCase):
         qk = quadkey.QuadKey(''.join(['0'] * 10))
         self.assertEqual(int(qk.area()), 1531607591)
 
+    def testInheritance(self):
+        class TestQuadClass(quadkey.QuadKey):
+            def method1(self):
+                return f'QuadKey: {self}'
+            def method2(self):
+                return self.parent().method1()
+        TestQuadClass('033').method2()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi, I was facing some issues when trying to extend QuadKey via inheritance. Mainly when I inherited from `QuadKey`, my methods were not accessible after using some methods like `.difference()`  or `.parent()`. 

After looking into it, I figured out that this is because these methods are hardcoded to return a `QuadKey` instance instead of my own class. I fixed it by replacing `QuadKey` with `self.__class__()` or turning the method into a class method and converting `QuadKey` to `cls(...)`. Let me know what you think and if you have any suggestions for improvements! 